### PR TITLE
fix mean calculation when empty

### DIFF
--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -420,7 +420,7 @@ void TGSpeedo::SetScaleValue(Float_t val)
       fPeakVal = fValue;
 
    if (fBufferSize > 0) {
-      if (fBuffer.size() < fBufferCount + 1)
+      if ((Int_t)fBuffer.size() < fBufferCount + 1)
          fBuffer.push_back(fValue);
       else
          fBuffer[fBufferCount % fBufferSize] = fValue;

--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -234,6 +234,14 @@ TGDimension TGSpeedo::GetDefaultSize() const
 
 Float_t TGSpeedo::GetMean()
 {
+   if(fBufferSize == 0)
+   {
+      return fMeanVal;
+   }
+   else if(fBuffer.size() == 0)
+   {
+      return fMeanVal;//avoid dividing by zero in the line below
+   }
    return (Float_t) std::accumulate(fBuffer.begin(), fBuffer.end(), 0.0) / fBuffer.size();
 }
 
@@ -412,12 +420,12 @@ void TGSpeedo::SetScaleValue(Float_t val)
       fPeakVal = fValue;
 
    if (fBufferSize > 0) {
-      if (fBufferCount < fBufferSize)
+      if (fBuffer.size() < fBufferCount + 1)
          fBuffer.push_back(fValue);
       else
          fBuffer[fBufferCount % fBufferSize] = fValue;
       ++fBufferCount;
-      if ((fBufferCount + 1) > fBuffer.size())
+      if ((fBufferCount + 1) > fBufferSize)
          fBufferCount = 0;
    }
 
@@ -514,9 +522,8 @@ void TGSpeedo::DrawNeedle()
    Translate(80.0, angle, &xpk0, &ypk0);
    Translate(67.0, angle, &xpk1, &ypk1);
 
-   if (fBufferSize > 0) {
-      fMeanVal = GetMean();
-   }
+   fMeanVal = GetMean();
+
    // compute x/y position of the mean mark
    angle = fAngleMin + (fMeanVal / ((fScaleMax - fScaleMin) /
           (fAngleMax - fAngleMin)));


### PR DESCRIPTION
and revert 98e6332 because it is needed that fBufferCount to go above fBuffer.size() so that push_back gets called until filling the full buffer capacity (allocated by the vector.reserve() function)